### PR TITLE
Add missing attributes

### DIFF
--- a/addon/components/power-select-with-fallback.js
+++ b/addon/components/power-select-with-fallback.js
@@ -11,6 +11,9 @@ export default Ember.Component.extend({
   layout,
   tagName: '',
 
+  matchTriggerWidth: true,
+
+
   // CPs
   mustFallback: computed('fallback-when', function() {
     let fallbackStrategy = this.get('fallback-when');

--- a/addon/components/power-select-with-fallback.js
+++ b/addon/components/power-select-with-fallback.js
@@ -11,8 +11,6 @@ export default Ember.Component.extend({
   layout,
   tagName: '',
 
-  matchTriggerWidth: true,
-
 
   // CPs
   mustFallback: computed('fallback-when', function() {

--- a/addon/templates/components/power-select-with-fallback.hbs
+++ b/addon/templates/components/power-select-with-fallback.hbs
@@ -53,6 +53,7 @@
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
       matcher=matcher
+      matchTriggerWidth=matchTriggerWidth
       searchField=searchField
       renderInPlace=renderInPlace
       destination=destination
@@ -94,6 +95,7 @@
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
       matcher=matcher
+      matchTriggerWidth=matchTriggerWidth
       searchField=searchField
       renderInPlace=renderInPlace
       destination=destination

--- a/addon/templates/components/power-select-with-fallback.hbs
+++ b/addon/templates/components/power-select-with-fallback.hbs
@@ -112,8 +112,8 @@
       triggerClass=concatenatedTriggerClass
       dropdownClass=dropdownClass
       extra=extra
+      triggerId=triggerId
       as |option term|}}
       {{yield option term}}
   {{/power-select}}
 {{/if}}
-

--- a/addon/templates/components/power-select-with-fallback.hbs
+++ b/addon/templates/components/power-select-with-fallback.hbs
@@ -60,6 +60,7 @@
       search=search
       allowClear=allowClear
       verticalPosition=verticalPosition
+      horizontalPosition=horizontalPosition
       closeOnSelect=closeOnSelect
       opened=opened
       tabindex=tabindex
@@ -102,6 +103,7 @@
       search=search
       allowClear=allowClear
       verticalPosition=verticalPosition
+      horizontalPosition=horizontalPosition
       closeOnSelect=closeOnSelect
       opened=opened
       tabindex=tabindex


### PR DESCRIPTION
We are using `matchTriggerWidth` and `horizontalPosition` in the containing component which doesn't get mapped down to the underlying `ember-power-select`.