### PR TITLE
Add missing triggerId attr

### DIFF
--- a/addon/templates/components/power-select-with-fallback.hbs
+++ b/addon/templates/components/power-select-with-fallback.hbs
@@ -69,6 +69,7 @@
       triggerClass=concatenatedTriggerClass
       dropdownClass=dropdownClass
       extra=extra
+      triggerId=triggerId
       as |option term|}}
       {{yield option term}}
     {{else}}


### PR DESCRIPTION
## Purpose
PR #7 had the `triggerId` attr included in the else block but missing from the if block.