### PR TITLE
Bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "^2.10.0",
+    "ember-cli": "~3.4.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-deploy": "0.5.1",
@@ -49,9 +49,9 @@
     "mobile"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.10",
-    "ember-power-select": "^1.0.0-beta.31"
+    "ember-cli-babel": "^6.16.0",
+    "ember-cli-htmlbars": "^3.0.0",
+    "ember-power-select": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I'm no pro but after bumping these versions I could use this addon with the current EPS version whereas before it was not possible. If this needs anything else please let know.